### PR TITLE
Scala 2.13 (and drop 2.11)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,19 +9,19 @@ name := projectName
 
 description := "handlebars-scala maintenance fork"
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.12.8"
 
-crossScalaVersions := Seq("2.12.0", "2.11.8")
+crossScalaVersions := Seq("2.12.8", "2.13.0")
 
 scalacOptions += "-deprecation"
 
 scalacOptions += "-feature"
 
 libraryDependencies ++= Seq(
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5",
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   "org.slf4j" % "slf4j-api" % "1.6.4",
   "org.slf4j" % "slf4j-simple" % "1.6.4" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 licenses := Seq("BSD" -> url("http://www.opensource.org/licenses/bsd-license.php"))

--- a/src/main/scala/com/gilt/handlebars/scala/CachingHandlebars.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/CachingHandlebars.scala
@@ -35,7 +35,7 @@ object CachingHandlebars {
     helpers: Map[String, Helper[T]] = Map.empty[String, Helper[T]])(implicit contextFactory: BindingFactory[T]): Handlebars[T] = {
     if (file.exists()) {
       try {
-        val partials = PartialHelper.findAllPartials(file).mapValues(Handlebars(_))
+        val partials = PartialHelper.findAllPartials(file).mapValues(Handlebars(_)).toMap
         apply(Source.fromFile(file).mkString, partials, helpers, Some(file.getAbsolutePath))
       } catch {
         case ex: Exception => sys.error("Error while loading template\n%s".format(ex))

--- a/src/main/scala/com/gilt/handlebars/scala/binding/dynamic/DynamicBinding.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/binding/dynamic/DynamicBinding.scala
@@ -46,13 +46,13 @@ class DynamicBinding(val data: Any) extends FullBinding[Any] with Loggable {
   def render = if (isTruthy) data.toString else ""
 
   def isTruthy = data match {
-    case /* UndefinedValue |*/ None | Unit | Nil | null | false => false
+    case /* UndefinedValue |*/ None | () | Nil | null | false => false
     case _: scala.runtime.BoxedUnit => false
     case _ => true
   }
   override def toString = s"DynamicBinding($data)"
   override def isDefined = data match {
-    case /* UndefinedValue |*/ None | Unit | null => false
+    case /* UndefinedValue |*/ None | () | null => false
     case _ => true
   }
 

--- a/src/main/scala/com/gilt/handlebars/scala/parser/HandlebarsGrammar.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/parser/HandlebarsGrammar.scala
@@ -90,7 +90,7 @@ class HandlebarsGrammar(delimiters: (String, String)) extends JavaTokenParsers {
   }
 
   def hashSegment = (ID ~ EQUALS ~ param) ^^ {
-    case (i ~ _ ~ p) => Pair(i, p)
+    case (i ~ _ ~ p) => (i, p)
   }
 
   def partialName = (path | STRING | INTEGER) ^^ { PartialName(_) }
@@ -115,7 +115,7 @@ class HandlebarsGrammar(delimiters: (String, String)) extends JavaTokenParsers {
 
   def comment = mustachify("!" ~> CONTENT) ^^ { Comment(_) }
 
-  def blockify(prefix: Parser[String]): Parser[Pair[Mustache, Option[Program]]] = {
+  def blockify(prefix: Parser[String]): Parser[(Mustache, Option[Program])] = {
     blockstache(prefix) ~ opt(program) ~ mustachify("/" ~> pad(path)) >> {
       case (mustache ~ _ ~ close) if close != mustache.path => failure(mustache.path.string + " doesn't match " +
 close.string)

--- a/src/test/scala/com/gilt/handlebars/scala/binding/dynamic/DynamicBindingSpec.scala
+++ b/src/test/scala/com/gilt/handlebars/scala/binding/dynamic/DynamicBindingSpec.scala
@@ -9,7 +9,7 @@ class DynamicBindingSpec extends FunSpec with Matchers {
     if (v == null) return "null"
     v match {
       case Some(a) => s"Some(${d(a)})"
-      case Unit => "Unit"
+      case () => "Unit"
       case a: String => "\"%s\"" format a
       case _ => v.toString
     }
@@ -20,7 +20,7 @@ class DynamicBindingSpec extends FunSpec with Matchers {
       (value, truthy) <- List(
         (null         , false),
         (None        -> false),
-        (Unit        -> false),
+        (()        -> false),
         (false       -> false),
         (List()      -> false),
         (""          -> true), // DynamicBinding behavior does not match JavaScript truth evaluation here; We may wish to revise?
@@ -38,7 +38,7 @@ class DynamicBindingSpec extends FunSpec with Matchers {
         (List()      -> ""),
         (null         , ""),
         (None        -> ""),
-        (Unit        -> ""),
+        (()        -> ""),
         (false       -> ""),
         (""          -> ""),
         (0           -> "0"),
@@ -80,7 +80,7 @@ class DynamicBindingSpec extends FunSpec with Matchers {
       (value, expectation) <- List(
         (null         , None),
         (None        -> None),
-        (Unit        -> None),
+        (()        -> None),
         (""          -> Some(DynamicBinding(""))),
         (List()      -> Some(DynamicBinding(List()))),
         (0           -> Some(DynamicBinding(0))),

--- a/src/test/scala/com/gilt/handlebars/scala/partial/PartialHelperSpec.scala
+++ b/src/test/scala/com/gilt/handlebars/scala/partial/PartialHelperSpec.scala
@@ -41,8 +41,7 @@ class PartialHelperSpec extends FunSpec with Matchers {
         "partials/aPartial" -> "src/test/resources/partials/aPartial.handlebars",
         "partialWithinAPartial" -> "src/test/resources/partials/partialWithinAPartial.handlebars"
       )
-      val actual = partials.mapValues(_.getPath)
-
+      val actual = partials.mapValues(_.getPath).toMap
       actual should equal(expected)
     }
 
@@ -53,7 +52,7 @@ class PartialHelperSpec extends FunSpec with Matchers {
         "person" -> "src/test/resources/person.handlebars",
         "intermediate" -> "src/test/resources/intermediate.handlebars"
       )
-      val actual = partials.mapValues(_.getPath)
+      val actual = partials.mapValues(_.getPath).toMap
 
       actual should equal(expected)
     }


### PR DESCRIPTION
fixes #3 
2.11 drop because of this:

```
> ++ 2.11.12
[info] Setting version to 2.11.12
...
> test
...
[info] com.gilt.handlebars.scala.HandlebarsPerfSpec *** ABORTED ***
[info]   java.lang.AbstractMethodError: com.gilt.handlebars.scala.parser.HandlebarsGrammar.scala$util$parsing$combinator$Parsers$$lastNoSuccessVar()Lscala/util/DynamicVariable;
[info]   at scala.util.parsing.combinator.Parsers$$anon$2.apply(Parsers.scala:881)
[info]   at scala.util.parsing.combinator.RegexParsers$class.parse(RegexParsers.scala:160)
[info]   at com.gilt.handlebars.scala.parser.HandlebarsGrammar.parse(HandlebarsGrammar.scala:12)
[info]   at scala.util.parsing.combinator.RegexParsers$class.parseAll(RegexParsers.scala:176)
[info]   at com.gilt.handlebars.scala.parser.HandlebarsGrammar.parseAll(HandlebarsGrammar.scala:12)
[info]   at com.gilt.handlebars.scala.parser.HandlebarsGrammar.apply(HandlebarsGrammar.scala:19)
[info]   at com.gilt.handlebars.scala.parser.HandlebarsGrammar$.apply(HandlebarsGrammar.scala:8)
[info]   at com.gilt.handlebars.scala.parser.ProgramHelper$class.programFromString(ProgramHelper.scala:10)
[info]   at com.gilt.handlebars.scala.DefaultHandlebarsBuilder$.programFromString(HandlebarsBuilder.scala:34)
[info]   at com.gilt.handlebars.scala.DefaultHandlebarsBuilder$.apply(HandlebarsBuilder.scala:36)
[info]   ...
```